### PR TITLE
Specify custom download URLs for all platforms

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -287,7 +287,7 @@ Information about Slang compiler
 <pre>
 load("@rules_vulkan//docs:docs_hub.bzl", "download_sdk")
 
-download_sdk(<a href="#download_sdk-name">name</a>, <a href="#download_sdk-build_file">build_file</a>, <a href="#download_sdk-repo_mapping">repo_mapping</a>, <a href="#download_sdk-sha256">sha256</a>, <a href="#download_sdk-url">url</a>, <a href="#download_sdk-version">version</a>, <a href="#download_sdk-windows_skip_runtime">windows_skip_runtime</a>)
+download_sdk(<a href="#download_sdk-name">name</a>, <a href="#download_sdk-build_file">build_file</a>, <a href="#download_sdk-repo_mapping">repo_mapping</a>, <a href="#download_sdk-urls">urls</a>, <a href="#download_sdk-version">version</a>, <a href="#download_sdk-windows_skip_runtime">windows_skip_runtime</a>)
 </pre>
 
 A rule to handle download and unpack of the SDK for each major platform (Windows, Linux, MacOS).
@@ -303,8 +303,7 @@ These rely on command line installation described in "Getting started" docs on L
 | <a id="download_sdk-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="download_sdk-build_file"></a>build_file |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_vulkan//vulkan/private:template.BUILD"`  |
 | <a id="download_sdk-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
-| <a id="download_sdk-sha256"></a>sha256 |  SDK package checksum   | String | optional |  `""`  |
-| <a id="download_sdk-url"></a>url |  URL to download the SDK package from.<br><br>Can be empty, in this case the download URL will be inherited from the provided version.   | String | required |  |
+| <a id="download_sdk-urls"></a>urls |  URLs and SHA256 checksum for each platform.<br><br>Refer to the module extension doc for specifics.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
 | <a id="download_sdk-version"></a>version |  Vulkan SDK version to download and install.<br><br>This expects a version in the format of `1.4.313.0` or `1.4.313`. When 3 components are provided, `.0` will be appended automatically to make it 4 components.   | String | required |  |
 | <a id="download_sdk-windows_skip_runtime"></a>windows_skip_runtime |  Do not download and install Vulkan runtime package (e.g. `vulkan-1.dll` dependency) on Windows.<br><br>When `True`, the downloader with put `vulkan-1.dll` into the repository root directory.<br><br>This is useful if there is a system-wide Vulkan runtime already installed, otherwise this might lead to link/runtime issues when building CC targets.   | Boolean | optional |  `False`  |
 

--- a/vulkan/extensions.bzl
+++ b/vulkan/extensions.bzl
@@ -9,9 +9,8 @@ def _vulkan_sdk_impl(ctx):
         for tag in mod.tags.download:
             download_sdk(
                 name = "vulkan_sdk_{}".format(tag.version),
-                url = tag.url,
-                sha256 = tag.sha256,
                 version = tag.version,
+                urls = tag.urls,
             )
 
     return ctx.extension_metadata(
@@ -20,9 +19,56 @@ def _vulkan_sdk_impl(ctx):
 
 _download_tag = tag_class(
     attrs = {
-        "version": attr.string(mandatory = True),
-        "url": attr.string(),
-        "sha256": attr.string(),
+        "version": attr.string(
+            mandatory = True,
+            doc = "SDK version to install",
+        ),
+        "urls": attr.string_dict(
+            doc = """
+            A dictionary of custom URLs and hashes for the Vulkan SDK.
+
+            This allows using a custom mirror for Vulkan SDKs instead of LunarG.
+
+            The structure of the dictionary is similar to the one in `versions.bzl`.
+
+            A separate download URL and sha checksum is required for each platform.
+            LunarG currently uses the following platforms:
+            - `windows` - for Windows 64-bit
+            - `warm` - Windows ARM64.
+            - `mac` - Mac OS
+            - `linux` - Linux
+
+            Each entry required to provide `url` and `sha` fields.
+            Additionally, on Windows platforms, `runtime_url` and `runtime_sha` can be used to provide URLs
+            for the runtime package.
+
+            Example:
+            ```bazel
+            custom_urls = {
+                "linux": {
+                    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz",
+                    "sha": "4e957b66ade85eeaee95932aa7e3b45aea64db373c58a5eaefc8228cc71445c2",
+                },
+                "mac": {
+                    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/mac/vulkansdk-macos-1.4.313.0.zip",
+                    "sha": "782a966ef4d5d68acaa933ff45215df2e34f286df8f6077270202f218110dc20",
+                },
+                "windows": {
+                    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe",
+                    "sha": "b643ca8ab4aea5c47b9c4e021a0b33b3a13871bf1d8131e162a9e48c257c4694",
+                    "runtime_url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanRT-X64-1.4.313.0-Components.zip",
+                    "runtime_sha": "e8d37913185142270a2bc1b3e1f8f498a4edf47405fddda666f2f38b30ca944b",
+                },
+                "warm": {
+                    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/warm/vulkansdk-windows-ARM64-1.4.313.0.exe",
+                    "sha": "b19a8683df982d302fec07c110962153f02a2e5cf1e5118ff72d8532aa5fc567",
+                    "runtime_url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/warm/VulkanRT-ARM64-1.4.313.0-Components.zip",
+                    "runtime_sha": "6335a8d6b7ab85861025c2546f5f52384ff18a6d9346d350c2a0bf3b7524829a",
+                },
+            }
+            ```
+            """,
+        ),
     },
 )
 


### PR DESCRIPTION
Previously we could specify custom URL and SHA only for "current" platform, which isn't exactly right. Now, we can specify a list of URLs for all platforms.