### PR TITLE
Update HLSL shader rule to support custom output file names

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,15 +54,15 @@ The target will output <name>.cso or <name>.spv (when targeting spirv) file with
 | <a id="hlsl_shader-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="hlsl_shader-src"></a>src |  Input HLSL shader source file   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="hlsl_shader-hdrs"></a>hdrs |  List of header files dependencies to be included in the shader compilation   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="hlsl_shader-asm"></a>asm |  Output assembly code listing file (-Fc <file>). This will produce <name>.asm file   | Boolean | optional |  `False`  |
+| <a id="hlsl_shader-asm"></a>asm |  Output assembly code listing file to the specified path (-Fc <file>)   | String | optional |  `""`  |
 | <a id="hlsl_shader-def_root_sig"></a>def_root_sig |  Read root signature from a #define (-rootsig-define <value>)   | String | optional |  `""`  |
 | <a id="hlsl_shader-defines"></a>defines |  List of macro defines   | List of strings | optional |  `[]`  |
 | <a id="hlsl_shader-entry"></a>entry |  Entry point name   | String | optional |  `"main"`  |
-| <a id="hlsl_shader-hash"></a>hash |  Output shader hash to the given file (-Fsh <file>). This will produce <name>.hash file   | Boolean | optional |  `False`  |
+| <a id="hlsl_shader-hash"></a>hash |  Output shader hash to the specified file (-Fsh <file>)   | String | optional |  `""`  |
 | <a id="hlsl_shader-hlsl"></a>hlsl |  HLSL version to use (2016, 2017, 2018, 2021)   | String | optional |  `""`  |
 | <a id="hlsl_shader-includes"></a>includes |  List of directories to be added to the CLI to search for include files   | List of strings | optional |  `[]`  |
 | <a id="hlsl_shader-opts"></a>opts |  Additional arguments to pass to the DXC compiler   | List of strings | optional |  `[]`  |
-| <a id="hlsl_shader-reflect"></a>reflect |  Output reflection to the given file (-Fre <file>). This will produce <name>.reflect file   | Boolean | optional |  `False`  |
+| <a id="hlsl_shader-reflect"></a>reflect |  Output reflection to the specified file (-Fre <file>)   | String | optional |  `""`  |
 | <a id="hlsl_shader-spirv"></a>spirv |  Generate SPIR-V code   | Boolean | optional |  `False`  |
 | <a id="hlsl_shader-target"></a>target |  Target profile (e.g., cs_6_0, ps_6_0, etc.)   | String | required |  |
 

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -8,7 +8,7 @@ hlsl_shader(
     name = "hello_hlsl",
     src = "shader.hlsl",
     hdrs = ["//common:common_headers"],
-    asm = True,  # Output assembly code
+    asm = "hello_hlsl.asm",  # Output assembly code
     defines = ["USE_VULKAN"],
     entry = "CSMain",
     hlsl = "2021",

--- a/vulkan/private/hlsl.bzl
+++ b/vulkan/private/hlsl.bzl
@@ -60,21 +60,21 @@ def _hlsl_shader_impl(ctx):
 
     # Output assembly code
     if ctx.attr.asm:
-        out = ctx.actions.declare_file(ctx.label.name + ".asm")
+        out = ctx.actions.declare_file(ctx.attr.asm)
 
         args.add("-Fc", out)
         all_files.append(out)
 
     # Output reflection
     if ctx.attr.reflect:
-        out = ctx.actions.declare_file(ctx.label.name + ".reflect")
+        out = ctx.actions.declare_file(ctx.attr.reflect)
 
         args.add("-Fre", out)
         all_files.append(out)
 
     # Output hash.
     if ctx.attr.hash:
-        out = ctx.actions.declare_file(ctx.label.name + ".hash")
+        out = ctx.actions.declare_file(ctx.attr.hash)
 
         args.add("-Fsh", out)
         all_files.append(out)
@@ -162,14 +162,14 @@ hlsl_shader = rule(
         "opts": attr.string_list(
             doc = "Additional arguments to pass to the DXC compiler",
         ),
-        "asm": attr.bool(
-            doc = "Output assembly code listing file (-Fc <file>). This will produce <name>.asm file",
+        "asm": attr.string(
+            doc = "Output assembly code listing file to the specified path (-Fc <file>)",
         ),
-        "reflect": attr.bool(
-            doc = "Output reflection to the given file (-Fre <file>). This will produce <name>.reflect file",
+        "reflect": attr.string(
+            doc = "Output reflection to the specified file (-Fre <file>)",
         ),
-        "hash": attr.bool(
-            doc = "Output shader hash to the given file (-Fsh <file>). This will produce <name>.hash file",
+        "hash": attr.string(
+            doc = "Output shader hash to the specified file (-Fsh <file>)",
         ),
         "_extra_opts": attr.label(
             default = "//vulkan/settings:dxc_opts",


### PR DESCRIPTION
Change asm, reflect, and hash attributes from boolean flags to string attributes that specify custom output file paths, similar to slang_shader's reflect attribute. This provides more flexibility in naming generated files.