### PR TITLE
Update ShaderInfo to use File objects instead of paths

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -224,10 +224,10 @@ This is useful for building all kind of shader databases.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="ShaderInfo-assembly"></a>assembly |  Path to assembly output file (if generated, HLSL-specific)    |
-| <a id="ShaderInfo-reflection"></a>reflection |  Path to reflection output file (if generated)    |
-| <a id="ShaderInfo-hash"></a>hash |  Path to hash output file (if generated, HLSL-specific)    |
-| <a id="ShaderInfo-depfile"></a>depfile |  Path to dependency output file (if generated, Slang-specific)    |
+| <a id="ShaderInfo-assembly"></a>assembly |  Assembly output file (if generated, HLSL-specific)    |
+| <a id="ShaderInfo-reflection"></a>reflection |  Reflection output file (if generated)    |
+| <a id="ShaderInfo-hash"></a>hash |  Hash output file (if generated, HLSL-specific)    |
+| <a id="ShaderInfo-depfile"></a>depfile |  Dependency output file (if generated, Slang-specific)    |
 | <a id="ShaderInfo-entry"></a>entry |  Shader entry point function name    |
 | <a id="ShaderInfo-stage"></a>stage |  Shader stage    |
 | <a id="ShaderInfo-defines"></a>defines |  List of shader defines used during compilation    |

--- a/e2e/smoke/metadata.bzl
+++ b/e2e/smoke/metadata.bzl
@@ -36,15 +36,15 @@ def _shader_metadata_impl(ctx):
             # Add optional output files if they exist
             optional_outputs = {}
             if hasattr(info, "assembly") and info.assembly:
-                optional_outputs["assembly"] = info.assembly
+                optional_outputs["assembly"] = info.assembly.path
                 assembly_files.append(info.assembly)
             if hasattr(info, "reflection") and info.reflection:
-                optional_outputs["reflection"] = info.reflection
+                optional_outputs["reflection"] = info.reflection.path
                 reflection_files.append(info.reflection)
             if hasattr(info, "hash") and info.hash:
-                optional_outputs["hash"] = info.hash
+                optional_outputs["hash"] = info.hash.path
             if hasattr(info, "depfile") and info.depfile:
-                optional_outputs["depfile"] = info.depfile
+                optional_outputs["depfile"] = info.depfile.path
                 dependency_files.append(info.depfile)
 
             if optional_outputs:
@@ -73,9 +73,9 @@ def _shader_metadata_impl(ctx):
     metadata = {
         "summary": summary,
         "shaders": shader_database,
-        "reflection_files": reflection_files,
-        "assembly_files": assembly_files,
-        "dependency_files": dependency_files,
+        "reflection_files": [f.path for f in reflection_files],
+        "assembly_files": [f.path for f in assembly_files],
+        "dependency_files": [f.path for f in dependency_files],
     }
 
     out = ctx.actions.declare_file(ctx.attr.out)

--- a/vulkan/private/hlsl.bzl
+++ b/vulkan/private/hlsl.bzl
@@ -112,9 +112,9 @@ def _hlsl_shader_impl(ctx):
         ),
         ShaderInfo(
             entry = ctx.attr.entry,
-            assembly = asm_file.path if asm_file else None,
-            reflection = reflection_file.path if reflection_file else None,
-            hash = hash_file.path if hash_file else None,
+            assembly = asm_file if asm_file else None,
+            reflection = reflection_file if reflection_file else None,
+            hash = hash_file if hash_file else None,
             depfile = None,
             stage = _map_stage(ctx.attr.target),
             defines = ctx.attr.defines,

--- a/vulkan/private/slang.bzl
+++ b/vulkan/private/slang.bzl
@@ -80,9 +80,9 @@ def _slang_shader_impl(ctx):
         ShaderInfo(
             entry = ctx.attr.entry,
             assembly = None,
-            reflection = reflection_file.path if reflection_file else None,
+            reflection = reflection_file if reflection_file else None,
             hash = None,
-            depfile = depfile_file.path if depfile_file else None,
+            depfile = depfile_file if depfile_file else None,
             stage = ctx.attr.stage,
             defines = ctx.attr.defines,
             target = ctx.attr.target,

--- a/vulkan/private/spirv_cross.bzl
+++ b/vulkan/private/spirv_cross.bzl
@@ -53,6 +53,10 @@ def _spirv_cross_impl(ctx):
         DefaultInfo(files = depset([output_file])),
         ShaderInfo(
             entry = entry,
+            assembly = None,
+            reflection = None,
+            hash = None,
+            depfile = None,
             stage = stage,
             defines = shader_info.defines if shader_info else [],
             target = ctx.attr.backend,

--- a/vulkan/providers.bzl
+++ b/vulkan/providers.bzl
@@ -9,10 +9,10 @@ ShaderInfo = provider(
     This is useful for building all kind of shader databases.
     """,
     fields = {
-        "assembly": "Path to assembly output file (if generated, HLSL-specific)",
-        "reflection": "Path to reflection output file (if generated)",
-        "hash": "Path to hash output file (if generated, HLSL-specific)",
-        "depfile": "Path to dependency output file (if generated, Slang-specific)",
+        "assembly": "Assembly output file (if generated, HLSL-specific)",
+        "reflection": "Reflection output file (if generated)",
+        "hash": "Hash output file (if generated, HLSL-specific)",
+        "depfile": "Dependency output file (if generated, Slang-specific)",
         "entry": "Shader entry point function name",
         "stage": "Shader stage",
         "defines": "List of shader defines used during compilation",


### PR DESCRIPTION
- Updates ShaderInfo provider to return actual File objects instead of string paths for better type safety
- Modifies all shader compilers (HLSL, Slang, spirv_cross) to return file objects in ShaderInfo
- Fixes metadata aggregation to handle file objects correctly when encoding JSON
