### PR TITLE
Refactor platform detection to use aspect_bazel_lib repo_utils

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,8 +7,8 @@ module(
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.17.1")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "2.17.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)

--- a/vulkan/private/BUILD
+++ b/vulkan/private/BUILD
@@ -13,4 +13,5 @@ bzl_library(
         "versions.bzl",
     ],
     visibility = ["//visibility:public"],
+    deps = ["@aspect_bazel_lib//lib:repo_utils"],
 )

--- a/vulkan/private/download.bzl
+++ b/vulkan/private/download.bzl
@@ -2,6 +2,7 @@
 Vulkan SDK downloader.
 """
 
+load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load(":resolve.bzl", "find_exact", "normalize_os", "normalize_version")
 
 def _install_linux(ctx, urls, version, attrs):
@@ -131,7 +132,7 @@ def _download_impl(ctx):
         urls = find_exact(version)
 
     # Fetch URLs for the current platform
-    platform = normalize_os(ctx.os.name, ctx.os.arch)
+    platform = normalize_os(ctx)
     urls = urls.get(platform, None)
     if not urls:
         fail("Download URLs not found for platform {} and SDK {}", platform, version)
@@ -143,11 +144,11 @@ def _download_impl(ctx):
         "{vulkan_deps}": "",  # Windows only
     }
 
-    if platform == "linux":
+    if repo_utils.is_linux(ctx):
         _install_linux(ctx, urls, version, attrs)
-    elif platform == "mac":
+    elif repo_utils.is_darwin(ctx):
         _install_macos(ctx, urls, version, attrs)
-    elif platform in ["windows", "warm"]:
+    elif repo_utils.is_windows(ctx):
         _install_windows(ctx, urls, version, attrs)
     else:
         fail("Unsupported OS: {}".format(platform))

--- a/vulkan/private/resolve.bzl
+++ b/vulkan/private/resolve.bzl
@@ -5,7 +5,6 @@ Module to resolve download URL and checksum from the provided SDK version.
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load(":versions.bzl", "VERSIONS")
 
-
 def normalize_os(ctx):
     """
     Convert repository context to LunarG platform name using repo_utils.

--- a/vulkan/private/resolve.bzl
+++ b/vulkan/private/resolve.bzl
@@ -2,29 +2,38 @@
 Module to resolve download URL and checksum from the provided SDK version.
 """
 
+load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
 load(":versions.bzl", "VERSIONS")
 
-def normalize_os(os, arch):
+
+def normalize_os(ctx):
     """
-    Convert Bazel OS string to LunarG platform name.
+    Convert repository context to LunarG platform name using repo_utils.
 
     Args:
-        os: OS name fetched from the repository context.
-        arch: Arch name.
+        ctx: Repository context.
     Returns:
         Platform name
     """
-    if os.startswith("linux"):
-        return "linux"
-    elif os.startswith("mac"):
-        return "mac"
-    elif os.startswith("win"):
-        if arch.startswith("arm"):
-            return "warm"
-        else:
-            return "windows"
-    else:
-        fail("Unsupported OS: {}".format(os))
+    platform = repo_utils.platform(ctx)
+
+    # Map repo_utils platform names (os_arch) to LunarG platform names
+    platform_mapping = {
+        "darwin_amd64": "mac",
+        "darwin_arm64": "mac",
+        "linux_amd64": "linux",
+        "linux_arm64": "linux",
+        "linux_s390x": "linux",
+        "linux_ppc64le": "linux",
+        "windows_amd64": "windows",
+        "windows_arm64": "warm",
+    }
+
+    vulkan_platform = platform_mapping.get(platform)
+    if not vulkan_platform:
+        fail("Unsupported platform: {}".format(platform))
+
+    return vulkan_platform
 
 def normalize_version(version):
     """


### PR DESCRIPTION
- Replace manual platform detection with standardized helpers from aspect_bazel_lib
- Use `repo_utils.platform()` with explicit mapping to Vulkan platform names  
- Replace manual OS checks with `repo_utils.is_linux/is_darwin/is_windows`
- Move aspect_bazel_lib from dev dependency to runtime dependency
