### PR TITLE
Add binary field to ShaderInfo provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -265,7 +265,7 @@ A collection of shader infos.
 <pre>
 load("@rules_vulkan//vulkan:defs.bzl", "ShaderInfo")
 
-ShaderInfo(<a href="#ShaderInfo-assembly">assembly</a>, <a href="#ShaderInfo-reflection">reflection</a>, <a href="#ShaderInfo-hash">hash</a>, <a href="#ShaderInfo-depfile">depfile</a>, <a href="#ShaderInfo-entry">entry</a>, <a href="#ShaderInfo-stage">stage</a>, <a href="#ShaderInfo-defines">defines</a>, <a href="#ShaderInfo-target">target</a>)
+ShaderInfo(<a href="#ShaderInfo-binary">binary</a>, <a href="#ShaderInfo-assembly">assembly</a>, <a href="#ShaderInfo-reflection">reflection</a>, <a href="#ShaderInfo-hash">hash</a>, <a href="#ShaderInfo-depfile">depfile</a>, <a href="#ShaderInfo-entry">entry</a>, <a href="#ShaderInfo-stage">stage</a>, <a href="#ShaderInfo-defines">defines</a>, <a href="#ShaderInfo-target">target</a>)
 </pre>
 
 Shader metadata returned by the shader targets during compilation.
@@ -276,6 +276,7 @@ This is useful for building all kind of shader databases.
 
 | Name  | Description |
 | :------------- | :------------- |
+| <a id="ShaderInfo-binary"></a>binary |  Binary output file containing the compiled shader bytecode    |
 | <a id="ShaderInfo-assembly"></a>assembly |  Assembly output file (if generated, HLSL-specific)    |
 | <a id="ShaderInfo-reflection"></a>reflection |  Reflection output file (if generated)    |
 | <a id="ShaderInfo-hash"></a>hash |  Hash output file (if generated, HLSL-specific)    |

--- a/vulkan/private/glsl.bzl
+++ b/vulkan/private/glsl.bzl
@@ -62,6 +62,7 @@ def _hlsl_shader_impl(ctx):
             all_files = depset(all_files),
         ),
         ShaderInfo(
+            binary = compiled_file,
             entry = "main",
             assembly = None,
             reflection = None,

--- a/vulkan/private/hlsl.bzl
+++ b/vulkan/private/hlsl.bzl
@@ -111,6 +111,7 @@ def _hlsl_shader_impl(ctx):
             all_files = depset(all_files),
         ),
         ShaderInfo(
+            binary = compiled_file,
             entry = ctx.attr.entry,
             assembly = asm_file if asm_file else None,
             reflection = reflection_file if reflection_file else None,

--- a/vulkan/private/slang.bzl
+++ b/vulkan/private/slang.bzl
@@ -78,6 +78,7 @@ def _slang_shader_impl(ctx):
             all_files = depset(all_files),
         ),
         ShaderInfo(
+            binary = compiled_file,
             entry = ctx.attr.entry,
             assembly = None,
             reflection = reflection_file if reflection_file else None,

--- a/vulkan/private/spirv_cross.bzl
+++ b/vulkan/private/spirv_cross.bzl
@@ -52,6 +52,7 @@ def _spirv_cross_impl(ctx):
     return [
         DefaultInfo(files = depset([output_file])),
         ShaderInfo(
+            binary = output_file,
             entry = entry,
             assembly = None,
             reflection = None,

--- a/vulkan/providers.bzl
+++ b/vulkan/providers.bzl
@@ -9,6 +9,7 @@ ShaderInfo = provider(
     This is useful for building all kind of shader databases.
     """,
     fields = {
+        "binary": "Binary output file containing the compiled shader bytecode",
         "assembly": "Assembly output file (if generated, HLSL-specific)",
         "reflection": "Reflection output file (if generated)",
         "hash": "Hash output file (if generated, HLSL-specific)",


### PR DESCRIPTION
Adds a binary field to ShaderInfo that contains the main compiled shader bytecode output file. This provides direct access to the primary compilation artifact for building shader databases and other tooling.