### PR TITLE
Fix permissions when extracting bundle on MacOS

### DIFF
--- a/vulkan/private/download.bzl
+++ b/vulkan/private/download.bzl
@@ -27,6 +27,7 @@ def _install_macos(ctx, urls, version, attrs):
     ctx.download_and_extract(
         urls["url"],
         sha256 = urls["sha"],
+        output = "installer",
     )
 
     # Install Vulkan components from terminal
@@ -43,7 +44,7 @@ def _install_macos(ctx, urls, version, attrs):
         ctx.report_progress("Running installer...")
         ctx.execute(
             [
-                "./vulkansdk-macOS-{0}.app/Contents/MacOS/vulkansdk-macOS-{0}".format(version),
+                "./installer/vulkansdk-macOS-{0}.app/Contents/MacOS/vulkansdk-macOS-{0}".format(version),
                 "--root",
                 ctx.path("unpack"),  # Warning: The installation path cannot be relative, please specify an absolute path.
                 "--accept-licenses",


### PR DESCRIPTION
Fixes error:
`
Error in download_and_extract: java.io.IOException: Error extracting
  /private/var/tmp/_bazel_mp/55a17e38e50415d39c648e51dddf02c4/external/rules_vulkan++vulkan_sdk+vk_sdk/temp13577855723665435206/vulkansdk-macos-1.4.313.0.zip to
  /private/var/tmp/_bazel_mp/55a17e38e50415d39c648e51dddf02c4/external/rules_vulkan++vulkan_sdk+vk_sdk/temp13577855723665435206:
  /private/var/tmp/_bazel_mp/55a17e38e50415d39c648e51dddf02c4/external/rules_vulkan++vulkan_sdk+vk_sdk/vulkansdk-macOS-1.4.313.0.app (Operation not permitted)
`