### PR TITLE
Remove spirv and hlsl attributes from hlsl_shader; pass via opts instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ hlsl_shader(
     src = "shader.hlsl",
     entry = "CSMain",
     target = "cs_6_0",
-    spirv = True,
+    opts = ["-spirv"],
     hdrs = [":common_headers"],
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Rule to compile GLSL shader.
 | <a id="glsl_shader-hdrs"></a>hdrs |  List of header file dependencies for shader compilation.<br><br>Each unique directory containing a header file automatically generates a `-I` flag, so the compiler can find headers included by filename (e.g. `#include "common.h"`). These files are also added as action inputs so that Bazel tracks them as dependencies and triggers rebuilds when they change.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="glsl_shader-defines"></a>defines |  List of macro defines   | List of strings | optional |  `[]`  |
 | <a id="glsl_shader-includes"></a>includes |  List of include search directories, resolved relative to the package.<br><br>Each entry produces two `-I` flags:<br><br>- Source tree path (e.g. `foo/bar/common`) — for headers checked into the repository, when the include   path you need differs from the directory that `hdrs` would auto-derive. For example, with a header at   `pkg/common/nested/helper.h` and `#include "nested/helper.h"`, `hdrs` auto-derives   `-I pkg/common/nested` but you actually need `-I pkg/common`. Adding `includes = ["common"]` provides   that. - Bin directory path (e.g. `bazel-out/.../bin/foo/bar/common`) — same as above, but for headers generated   by other rules (e.g. `genrule`), which are placed under the output directory rather than the source   tree.<br><br>Paths are constructed by joining the package path with the entry value (e.g. an entry `"common"` in package `foo/bar` resolves to `foo/bar/common`).<br><br>Use this when the auto-derived paths from `hdrs` are not sufficient — for example, when the `#include` directive uses a path prefix that differs from the header file's immediate directory (e.g. `#include "subdir/header.h"` where the header is at `pkg/subdir/header.h` and `-I pkg` is needed).   | List of strings | optional |  `[]`  |
-| <a id="glsl_shader-opts"></a>opts |  Additional arguments to pass to the compiler   | List of strings | optional |  `[]`  |
+| <a id="glsl_shader-opts"></a>opts |  Additional arguments to pass to the compiler.<br><br>Flags from `//vulkan/settings:glslc_opts` are appended after these, so the global build setting takes precedence on conflicting flags.   | List of strings | optional |  `[]`  |
 | <a id="glsl_shader-stage"></a>stage |  Shader stage (vertex, vert, fragment, frag, etc)   | String | required |  |
 | <a id="glsl_shader-std"></a>std |  Version and profile for GLSL input files.<br><br>Possible values are concatenations of version and profile, e.g. `310es`, `450core`, etc.   | String | optional |  `""`  |
 | <a id="glsl_shader-target_env"></a>target_env |  Set the target client environment, and the semantics of warnings and errors.<br><br>An optional suffix can specify the client version.   | String | optional |  `""`  |
@@ -38,13 +38,15 @@ Rule to compile GLSL shader.
 <pre>
 load("@rules_vulkan//vulkan:defs.bzl", "hlsl_shader")
 
-hlsl_shader(<a href="#hlsl_shader-name">name</a>, <a href="#hlsl_shader-src">src</a>, <a href="#hlsl_shader-hdrs">hdrs</a>, <a href="#hlsl_shader-asm">asm</a>, <a href="#hlsl_shader-def_root_sig">def_root_sig</a>, <a href="#hlsl_shader-defines">defines</a>, <a href="#hlsl_shader-entry">entry</a>, <a href="#hlsl_shader-hash">hash</a>, <a href="#hlsl_shader-hlsl">hlsl</a>, <a href="#hlsl_shader-includes">includes</a>, <a href="#hlsl_shader-opts">opts</a>, <a href="#hlsl_shader-reflect">reflect</a>,
-            <a href="#hlsl_shader-spirv">spirv</a>, <a href="#hlsl_shader-target">target</a>)
+hlsl_shader(<a href="#hlsl_shader-name">name</a>, <a href="#hlsl_shader-src">src</a>, <a href="#hlsl_shader-hdrs">hdrs</a>, <a href="#hlsl_shader-asm">asm</a>, <a href="#hlsl_shader-def_root_sig">def_root_sig</a>, <a href="#hlsl_shader-defines">defines</a>, <a href="#hlsl_shader-entry">entry</a>, <a href="#hlsl_shader-hash">hash</a>, <a href="#hlsl_shader-includes">includes</a>, <a href="#hlsl_shader-opts">opts</a>, <a href="#hlsl_shader-reflect">reflect</a>,
+            <a href="#hlsl_shader-target">target</a>)
 </pre>
 
 Rule to compile HLSL shaders using DirectXShaderCompiler.
 
-The target will output <name>.cso or <name>.spv (when targeting spirv) file with bytecode output.
+The target outputs `<name>.cso` by default, or `<name>.spv` when `-spirv` is passed via `opts` or the global
+`//vulkan/settings:dxc_opts` build setting. Pass other DXC flags the same way — e.g. `-HV 2021` for HLSL version,
+`-enable-16bit-types`, etc.
 
 **ATTRIBUTES**
 
@@ -59,11 +61,9 @@ The target will output <name>.cso or <name>.spv (when targeting spirv) file with
 | <a id="hlsl_shader-defines"></a>defines |  List of macro defines   | List of strings | optional |  `[]`  |
 | <a id="hlsl_shader-entry"></a>entry |  Entry point name   | String | optional |  `"main"`  |
 | <a id="hlsl_shader-hash"></a>hash |  Output shader hash to the specified file (-Fsh <file>)   | String | optional |  `""`  |
-| <a id="hlsl_shader-hlsl"></a>hlsl |  HLSL version to use (2016, 2017, 2018, 2021)   | String | optional |  `""`  |
 | <a id="hlsl_shader-includes"></a>includes |  List of include search directories, resolved relative to the package.<br><br>Each entry produces two `-I` flags:<br><br>- Source tree path (e.g. `foo/bar/common`) — for headers checked into the repository, when the include   path you need differs from the directory that `hdrs` would auto-derive. For example, with a header at   `pkg/common/nested/helper.h` and `#include "nested/helper.h"`, `hdrs` auto-derives   `-I pkg/common/nested` but you actually need `-I pkg/common`. Adding `includes = ["common"]` provides   that. - Bin directory path (e.g. `bazel-out/.../bin/foo/bar/common`) — same as above, but for headers generated   by other rules (e.g. `genrule`), which are placed under the output directory rather than the source   tree.<br><br>Paths are constructed by joining the package path with the entry value (e.g. an entry `"common"` in package `foo/bar` resolves to `foo/bar/common`).<br><br>Use this when the auto-derived paths from `hdrs` are not sufficient — for example, when the `#include` directive uses a path prefix that differs from the header file's immediate directory (e.g. `#include "subdir/header.h"` where the header is at `pkg/subdir/header.h` and `-I pkg` is needed).   | List of strings | optional |  `[]`  |
-| <a id="hlsl_shader-opts"></a>opts |  Additional arguments to pass to the DXC compiler   | List of strings | optional |  `[]`  |
+| <a id="hlsl_shader-opts"></a>opts |  Additional arguments to pass to the DXC compiler.<br><br>Pass `-spirv` here (or globally via `//vulkan/settings:dxc_opts`) to emit SPIR-V; the rule detects the flag and selects the `.spv` output extension accordingly. Otherwise the rule emits `.cso` (DXIL).<br><br>Flags from `//vulkan/settings:dxc_opts` are appended after these, so the global build setting takes precedence on conflicting flags.   | List of strings | optional |  `[]`  |
 | <a id="hlsl_shader-reflect"></a>reflect |  Output reflection to the specified file (-Fre <file>)   | String | optional |  `""`  |
-| <a id="hlsl_shader-spirv"></a>spirv |  Generate SPIR-V code   | Boolean | optional |  `False`  |
 | <a id="hlsl_shader-target"></a>target |  Target profile (e.g., cs_6_0, ps_6_0, etc.)   | String | required |  |
 
 
@@ -176,7 +176,7 @@ Rule to compile Slang shaders.
 | <a id="slang_shader-entry"></a>entry |  Entry point name   | String | optional |  `""`  |
 | <a id="slang_shader-includes"></a>includes |  List of include search directories, resolved relative to the package.<br><br>Each entry produces two `-I` flags:<br><br>- Source tree path (e.g. `foo/bar/common`) — for headers checked into the repository, when the include   path you need differs from the directory that `hdrs` would auto-derive. For example, with a header at   `pkg/common/nested/helper.h` and `#include "nested/helper.h"`, `hdrs` auto-derives   `-I pkg/common/nested` but you actually need `-I pkg/common`. Adding `includes = ["common"]` provides   that. - Bin directory path (e.g. `bazel-out/.../bin/foo/bar/common`) — same as above, but for headers generated   by other rules (e.g. `genrule`), which are placed under the output directory rather than the source   tree.<br><br>Paths are constructed by joining the package path with the entry value (e.g. an entry `"common"` in package `foo/bar` resolves to `foo/bar/common`).<br><br>Use this when the auto-derived paths from `hdrs` are not sufficient — for example, when the `#include` directive uses a path prefix that differs from the header file's immediate directory (e.g. `#include "subdir/header.h"` where the header is at `pkg/subdir/header.h` and `-I pkg` is needed).   | List of strings | optional |  `[]`  |
 | <a id="slang_shader-lang"></a>lang |  Set source language for the shader (slang, hlsl, glsl, cpp, etc)   | String | optional |  `""`  |
-| <a id="slang_shader-opts"></a>opts |  Additional arguments to pass to the compiler   | List of strings | optional |  `[]`  |
+| <a id="slang_shader-opts"></a>opts |  Additional arguments to pass to the compiler.<br><br>Flags from `//vulkan/settings:slangc_opts` are appended after these, so the global build setting takes precedence on conflicting flags.   | List of strings | optional |  `[]`  |
 | <a id="slang_shader-profile"></a>profile |  Shader profile for code generation (sm_6_6, vs_6_6, glsl_460, etc)   | String | optional |  `""`  |
 | <a id="slang_shader-reflect"></a>reflect |  Emit reflection data in JSON format to a file   | String | optional |  `""`  |
 | <a id="slang_shader-stage"></a>stage |  Stage of an entry point function (vertex, pixel, compute, etc)   | String | optional |  `""`  |

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -12,9 +12,12 @@ hlsl_shader(
     asm = "hello_hlsl.asm",  # Output assembly code
     defines = ["USE_VULKAN"],
     entry = "CSMain",
-    hlsl = "2021",
-    opts = ["-Ges"],  # Additional compiler options.
-    spirv = True,
+    opts = [
+        "-HV",
+        "2021",
+        "-Ges",
+        "-spirv",
+    ],
     target = "cs_6_0",
 )
 

--- a/vulkan/private/glsl.bzl
+++ b/vulkan/private/glsl.bzl
@@ -40,7 +40,7 @@ def _glsl_shader_impl(ctx):
 
     # Append build settings options.
     extra_opts = ctx.attr._extra_opts[BuildSettingInfo].value
-    args.add_all(extra_opts, uniquify = True)
+    args.add_all(extra_opts)
 
     # Specify shader inputs.
     src = ctx.file.src
@@ -147,7 +147,11 @@ glsl_shader = rule(
             """,
         ),
         "opts": attr.string_list(
-            doc = "Additional arguments to pass to the compiler",
+            doc = """Additional arguments to pass to the compiler.
+
+            Flags from `//vulkan/settings:glslc_opts` are appended after these, so the global build setting takes
+            precedence on conflicting flags.
+            """,
         ),
         "_extra_opts": attr.label(
             default = "//vulkan/settings:glslc_opts",

--- a/vulkan/private/hlsl.bzl
+++ b/vulkan/private/hlsl.bzl
@@ -31,7 +31,11 @@ def _map_stage(target):
 def _hlsl_shader_impl(ctx):
     sdk = ctx.toolchains["//vulkan:toolchain_type"].info
 
-    ext = ".spv" if ctx.attr.spirv else ".cso"
+    extra_opts = ctx.attr._extra_opts[BuildSettingInfo].value
+
+    # Output extension follows the backend: `.spv` when `-spirv` is passed, `.cso` otherwise.
+    spirv = "-spirv" in ctx.attr.opts or "-spirv" in extra_opts
+    ext = ".spv" if spirv else ".cso"
     compiled_file = ctx.actions.declare_file(ctx.label.name + ext)
     all_files = [compiled_file]
 
@@ -50,10 +54,6 @@ def _hlsl_shader_impl(ctx):
 
     for include in resolve_includes(ctx):
         args.add("-I", include)
-
-    # Specify HLSL version
-    if ctx.attr.hlsl:
-        args.add("-HV", ctx.attr.hlsl)
 
     # Specify root signature from #define
     if ctx.attr.def_root_sig:
@@ -80,15 +80,11 @@ def _hlsl_shader_impl(ctx):
         args.add("-Fsh", hash_file)
         all_files.append(hash_file)
 
-    if ctx.attr.spirv:
-        args.add("-spirv")
-
     # Append user-defined extra arguments
     args.add_all(ctx.attr.opts)
 
     # Append build settings options.
-    extra_opts = ctx.attr._extra_opts[BuildSettingInfo].value
-    args.add_all(extra_opts, uniquify = True)
+    args.add_all(extra_opts)
 
     # Specify input shader source file
     src = ctx.file.src
@@ -129,7 +125,9 @@ hlsl_shader = rule(
     doc = """
     Rule to compile HLSL shaders using DirectXShaderCompiler.
 
-    The target will output <name>.cso or <name>.spv (when targeting spirv) file with bytecode output.
+    The target outputs `<name>.cso` by default, or `<name>.spv` when `-spirv` is passed via `opts` or the global
+    `//vulkan/settings:dxc_opts` build setting. Pass other DXC flags the same way — e.g. `-HV 2021` for HLSL version,
+    `-enable-16bit-types`, etc.
     """,
     attrs = {
         "src": attr.label(
@@ -179,17 +177,18 @@ hlsl_shader = rule(
             inputs so that Bazel tracks them as dependencies and triggers rebuilds when they change.
             """,
         ),
-        "hlsl": attr.string(
-            doc = "HLSL version to use (2016, 2017, 2018, 2021)",
-        ),
         "def_root_sig": attr.string(
             doc = "Read root signature from a #define (-rootsig-define <value>)",
         ),
-        "spirv": attr.bool(
-            doc = "Generate SPIR-V code",
-        ),
         "opts": attr.string_list(
-            doc = "Additional arguments to pass to the DXC compiler",
+            doc = """Additional arguments to pass to the DXC compiler.
+
+            Pass `-spirv` here (or globally via `//vulkan/settings:dxc_opts`) to emit SPIR-V; the rule detects the
+            flag and selects the `.spv` output extension accordingly. Otherwise the rule emits `.cso` (DXIL).
+
+            Flags from `//vulkan/settings:dxc_opts` are appended after these, so the global build setting takes
+            precedence on conflicting flags.
+            """,
         ),
         "asm": attr.string(
             doc = "Output assembly code listing file to the specified path (-Fc <file>)",

--- a/vulkan/private/slang.bzl
+++ b/vulkan/private/slang.bzl
@@ -54,7 +54,7 @@ def _slang_shader_impl(ctx):
 
     # Append build settings options.
     extra_opts = ctx.attr._extra_opts[BuildSettingInfo].value
-    args.add_all(extra_opts, uniquify = True)
+    args.add_all(extra_opts)
 
     # Input shader source file
     args.add_all(ctx.files.srcs)
@@ -161,7 +161,11 @@ slang_shader = rule(
             doc = "Set source language for the shader (slang, hlsl, glsl, cpp, etc)",
         ),
         "opts": attr.string_list(
-            doc = "Additional arguments to pass to the compiler",
+            doc = """Additional arguments to pass to the compiler.
+
+            Flags from `//vulkan/settings:slangc_opts` are appended after these, so the global build setting takes
+            precedence on conflicting flags.
+            """,
         ),
         "_extra_opts": attr.label(
             default = "//vulkan/settings:slangc_opts",


### PR DESCRIPTION
The `spirv` and `hlsl` attributes on `hlsl_shader` are pure flag passthroughs that force per-target edits for per-platform configuration. Remove both in favor of passing these flags through `opts` or the global `//vulkan/settings:dxc_opts` build setting, which can be scoped per platform via `.bazelrc`. The rule now detects `-spirv` in the flag list to select the output extension (`.spv` vs `.cso`).

Also removes `uniquify = True` from `args.add_all` on all three shader rules — it was corrupting paired flags like `-HV 2021` by dropping the flag token while keeping its value as a positional argument.