### PR TITLE
Dedupe identical vulkan_sdk toolchain tags across modules

### DIFF
--- a/vulkan/extensions.bzl
+++ b/vulkan/extensions.bzl
@@ -5,14 +5,28 @@ Module extension to manage Vulkan SDKs.
 load("//vulkan:defs.bzl", "INSTALL_ATTRS", "install_sdk")
 
 def _vulkan_sdk_impl(ctx):
+    generated = {}
     for mod in ctx.modules:
         for tag in mod.tags.toolchain:
-            name = tag.name
+            name = tag.name if tag.name else "vulkan_sdk_{}".format(tag.version)
             kwargs = {k: getattr(tag, k) for k in INSTALL_ATTRS}
-            install_sdk(
-                name = name if name else "vulkan_sdk_{}".format(tag.version),
-                **kwargs
-            )
+            if name in generated:
+                if generated[name] != kwargs:
+                    fail(
+                        ("Conflicting vulkan_sdk.toolchain tags resolve to the " +
+                         "same repository '{}' but request different attributes:\n" +
+                         "  {}\n" +
+                         "vs\n" +
+                         "  {}\n" +
+                         "Give one of the tags a distinct `name` to install both.").format(
+                            name,
+                            generated[name],
+                            kwargs,
+                        ),
+                    )
+                continue
+            generated[name] = kwargs
+            install_sdk(name = name, **kwargs)
 
     return ctx.extension_metadata(
         reproducible = True,


### PR DESCRIPTION
A module extension is evaluated once per build and receives the toolchain tags of every module that used it. When two modules request the same SDK version (e.g. a library and the app consuming it both pin 1.4.341.1), both tags resolve to the same repository name and install_sdk fails with a "repository already defined" error, breaking any multi-module graph that shares an SDK.

Dedupe by the resolved repository name so identical requests collapse to a single repo. When the same name is requested with different attributes -- a genuine conflict between two distinct SDKs -- fail with an actionable message telling the user to give one tag a distinct `name`, rather than silently installing whichever tag was iterated first.