### PR TITLE
Expose a :slang library target from the generated SDK repo

### DIFF
--- a/vulkan/private/template.BUILD
+++ b/vulkan/private/template.BUILD
@@ -76,6 +76,37 @@ cc_library(
 )
 
 #
+# Slang compiler library
+#
+
+cc_import(
+    name = "slang_dll",
+    interface_library = "sdk/Lib/slang.lib",
+    shared_library = "sdk/Bin/slang.dll",
+    target_compatible_with = [
+        "@platforms//os:windows",
+    ],
+)
+
+cc_library(
+    name = "slang",
+    # buildifier: disable=constant-glob
+    srcs = glob(
+        [
+            # Linux
+            "sdk/lib/libslang.so",
+            # macOS
+            "sdk/lib/libslang-compiler.*.dylib",
+        ],
+        allow_empty = True,
+    ),
+    deps = select({
+        "@platforms//os:windows": [":slang_dll"],
+        "//conditions:default": [],
+    }),
+)
+
+#
 # SDK compilers and tools
 #
 


### PR DESCRIPTION
The SDK bundles the slang compiler as a shared library, but consumers that link against it (e.g. shader-slang bindings) currently have to reach into sdk/lib with a hardcoded filename. On macOS that filename embeds the slang version (`libslang-compiler.0.2026.1.dylib`), which means every SDK bump breaks downstream BUILD files -- and downstream repos cannot glob files that live inside the SDK repository.

Add a `:slang` target to the generated BUILD, mirroring the existing `:vulkan` loader target:

- Windows: a cc_import pairing sdk/Lib/slang.lib with sdk/Bin/slang.dll.
- Linux/macOS: Glob the shared library. The macOS glob intentionally matches the versioned dylib rather than the `libslang-compiler.dylib` symlink: the library's install name (LC_ID_DYLIB) is `@rpath/libslang-compiler.<version>.dylib`, so the file must be staged under its versioned name for dyld to resolve it at runtime.

Since the glob runs inside the generated repo, consumers can now just depend on `@vulkan_sdk_<version>//:slang` regardless of which slang version the SDK bundles.